### PR TITLE
pelican: add id tags to headers

### DIFF
--- a/website/pelicanconf.py
+++ b/website/pelicanconf.py
@@ -18,6 +18,8 @@ GITHUB_URL = 'https://github.com/typesupply/opentype-feature-intro'
 
 DEFAULT_PAGINATION = False
 
+MD_EXTENSIONS = ['headerid']
+
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True
 


### PR DESCRIPTION
Use the `headerid` extension to add identifiers to HTML headers. This allows posting links to a particular section of the book.

See: https://quack1.me/pelican_title_id-en.html