### PR TITLE
Updating feature to work with Adobe CC

### DIFF
--- a/website/content/common-techniques.md
+++ b/website/content/common-techniques.md
@@ -95,7 +95,7 @@ This method has been around for as long as I have been working on OpenType featu
 
 Around 2006 [Kent Lew](http://www.fontbureau.com/people/KentLew/) asked me if I had any ideas for a better fraction implementation. Specifically, he was referring to the fact that with the existing implementation users had to manually select *only* the text that should be converted to fractions and apply the feature. If the feature was applied to more than just that text all numbers not in a fraction would be converted to numerators. This was a big problem in things like cookbooks where there could be *thousands* of little bits of text that had to be converted to fractions.
 
-I developed a new method that is built on the common form of writing fractions as an integer, a space, a numerator, a slash and a denominator. For example: `2 1/2`. The code considers 1-10 numbers followed by a slash followed by 1 or more numbers to be a fraction. The slash is converted to a fraction bar, the numbers before the slash are converted to numerators and the numbers after the slash are converted to denominators. If the new fraction is preceded by a number followed by a space, the space is converted to a thin space to pull the fraction closer to the integer. After I published the first version of this code, [Karsten Luecke](http://kltf.de) pointed out some problems with dates, German tax numbers and things like that. I published a new version that handles these properly and this version is below.
+I developed a new method that is built on the common form of writing fractions as an integer, a space, a numerator, a slash and a denominator. For example: `2 1/2`. The code considers 1-10 numbers followed by a slash followed by 1 or more numbers to be a fraction. The slash is converted to a fraction bar, the numbers before the slash are converted to numerators and the numbers after the slash are converted to denominators. If the new fraction is preceded by a number followed by a space, the space is converted to a thin space (which should not have a unicode value) to pull the fraction closer to the integer. After I published the first version of this code, [Karsten Luecke](http://kltf.de) pointed out some problems with dates, German tax numbers and things like that. I published a new version that handles these properly and this version is below.
 
 With this users can *globally* activate fractions. The only drawback that I have found with this is that it doesn’t allow numerators to be longer than 10 numbers long. In the unlikely event that a user runs into this problem, they can select the unconverted numerators and activate the numerator feature.
 
@@ -172,7 +172,7 @@ With this users can *globally* activate fractions. The only drawback that I have
             sub [fraction @figuresDenominator] @figures' by @figuresDenominator;
         } Denominator;
 
-        sub @figures space' @figuresNumerator by uni2009;
+        sub @figures space' @figuresNumerator by space.frac;
     } frac;
 
 ### Numerators


### PR DESCRIPTION
Newer versions of Indesign won't swap the space with uni2009 (thinspace). Changing to a non-encoded glyph fixes this.