### PR TITLE
Deleted exclude_dflt argument on the examples

### DIFF
--- a/Demo Font.ufo/features.fea
+++ b/Demo Font.ufo/features.fea
@@ -34,7 +34,7 @@ feature locl {
 
     script latn;
 
-        language NLD exclude_dflt;
+        language NLD;
             lookup DutchIJ {
                 sub IJ by IJ.dutch;
             } DutchIJ;

--- a/website/content/common-techniques.md
+++ b/website/content/common-techniques.md
@@ -64,7 +64,7 @@ The `locl` feature is specifically designed to implement global script and langu
 
         script latn;
 
-            language NLD exclude_dflt;
+            language NLD;
                 lookup DutchIJ {
                     sub IJ by IJ.dutch;
                 } DutchIJ;

--- a/website/content/style-guide.md
+++ b/website/content/style-guide.md
@@ -112,19 +112,19 @@ Script and language definitions each increase the indentation level by one level
 
         script latn;
 
-            language TRK exclude_dflt;
+            language TRK;
 
                 lookup IDOT {
                     sub i' by idotaccent;
                 } IDOT;
 
-            language AZE exclude_dflt;
+            language AZE;
                 lookup IDOT;
 
-            language CRT exclude_dflt;
+            language CRT;
                 lookup IDOT;
 
-            language ROM exclude_dflt;
+            language ROM;
 
                 lookup SCEDILLA {
                     sub scedilla by uni0219;


### PR DESCRIPTION
Deleted `exclude_dflt` argument on the examples as it is not really needed to make them work and can lead to misconceptions of what the argument is used for. From examples around the web and in talking to people it seems a lot of people think `exclude_dflt` is meant to exclude lookups that come after it from `languagesystem DFLT dflt` or from `script XXX; language dflt;`, when in reality it is the other way around; it's meant to exclude any lookups defined within `DFLT` or `dflt` from the language the argument is added to.

The Feature File Syntax documentation has a [good example of this (Example 2)](https://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#4.h), for once:

```
feature liga {
           # start of default rules that are applied under all language systems.
          lookup HAS_I {
           sub f f i by f_f_i;
           sub f i by f_i;
          } HAS_I;
 
          lookup NO_I {
           sub f f l by f_f_l;
           sub f f by f_f;
          } NO_I;
           
# end of default rules that are applied under all language systems.
 
     script latn;
         language dflt;              
# default lookup for latn included under all languages for the latn script
           
         sub f l by f_l;
         language DEU;              
# default lookups included under the DEU language..
         sub s s by germandbls;   # This is also included.
         language TRK exclude_dflt;   # default lookups are excluded.
          lookup NO_I;             #Only this lookup is included under the TRK language
 
     script cyrl;
        language SRB;
          sub c t by c_t; # this rule will apply only under script cyrl language SRB.
  } liga;
```